### PR TITLE
Feature/add install in tao

### DIFF
--- a/_templates/pci/creator/prompt.js
+++ b/_templates/pci/creator/prompt.js
@@ -45,11 +45,23 @@ module.exports = [
         type: "input",
         name: "label",
         message: "What's the PCI name to display?",
+        validate: value => {
+            if (!value.trim()) {
+                return `The label is mandatory. If you omit it, the TAO installer will refuse to install the PCI!`;
+            }
+            return true;
+        }
     },
     {
         type: "input",
         name: "description",
         message: "What does the PCI do?",
+        validate: value => {
+            if (!value.trim()) {
+                return `The description is mandatory. If you omit it, the TAO installer will refuse to install the PCI!`;
+            }
+            return true;
+        }
     },
     {
         type: 'select',

--- a/_templates/pci/creator/states.ejs.t
+++ b/_templates/pci/creator/states.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: <%=root%>/<%=typeIdentifier%>/creator/widget/states.js
+to: <%=root%>/<%=typeIdentifier%>/creator/widget/states/states.js
 ---
 define([
     'taoQtiItem/qtiCreator/widgets/states/factory',

--- a/_templates/pci/install/install.ejs.t
+++ b/_templates/pci/install/install.ejs.t
@@ -1,0 +1,17 @@
+---
+to: <%=root%>/<%=extension%>/scripts/install/RegisterPci<%=typeIdentifier.charAt(0).toUpperCase()%><%=typeIdentifier.substring(1)%>.php
+---
+<?php
+
+namespace oat\<%=extension%>\scripts\install;
+
+use oat\taoQtiItem\model\portableElement\action\RegisterPortableElement;
+
+class RegisterPci<%=typeIdentifier.charAt(0).toUpperCase()%><%=typeIdentifier.substring(1)%> extends RegisterPortableElement
+{
+    protected function getSourceDirectory()
+    {
+        $viewDir = \common_ext_ExtensionsManager::singleton()->getExtensionById('<%=extension%>')->getConstant('DIR_VIEWS');
+        return $viewDir . implode(DIRECTORY_SEPARATOR, ['js', 'pciCreator', 'ims', '<%=typeIdentifier%>']);
+    }
+}

--- a/_templates/pci/install/prompt.js
+++ b/_templates/pci/install/prompt.js
@@ -1,0 +1,49 @@
+const path = require('path');
+const fs = require('fs');
+
+const reIdentifier = /^[_a-zA-Z][_a-zA-Z0-9]*$/;
+
+let root = '';
+
+module.exports = [
+    {
+        type: 'input',
+        name: 'root',
+        message: 'Where is TAO installed (path)?',
+        initial: '.',
+        validate: value => {
+            const resolved = path.resolve(value);
+            if (!fs.existsSync(resolved)) {
+                return `${resolved} doesn't seems to exist`;
+            }
+            root = value;
+            return true;
+        }
+    },
+    {
+        type: 'input',
+        name: 'extension',
+        message: "What's the extension name?",
+        validate: value => {
+            if (!reIdentifier.test(value)) {
+                return `${value} is not a valid identifier`;
+            }
+            const resolved = path.resolve(root, value);
+            if (!fs.existsSync(resolved)) {
+                return `There is not extension named${resolved} doesn't seems to exist`;
+            }
+            return true;
+        }
+    },
+    {
+        type: 'input',
+        name: 'typeIdentifier',
+        message: "What's the PCI typeIdentifier?",
+        validate: value => {
+            if (!reIdentifier.test(value)) {
+                return `${value} is not a valid identifier`;
+            }
+            return true;
+        }
+    }
+];

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     },
     "scripts": {
         "pci:runtime": "hygen pci runtime",
-        "pci:creator": "hygen pci creator"
+        "pci:creator": "hygen pci creator",
+        "pci:install": "hygen pci install"
     },
     "author": "Open Assessment Technologies",
     "license": "GPL-2.0",


### PR DESCRIPTION
- Add a command for generating the PCI installer for TAO
- Fix the generated `states.js` file the creator.
- Also make the label and the description mandatory when generating the creator part