### PR TITLE
Fix/Wrong response format in the runtime

### DIFF
--- a/_templates/pci/runtime/runtime.ejs.t
+++ b/_templates/pci/runtime/runtime.ejs.t
@@ -46,7 +46,7 @@ define([
                  * @returns {Object} PCI formatted response
                  */
                 getResponse() {
-                    return { <%=jsonCardinality%> : answer };
+                    return { <%=jsonCardinality%> : { <%=baseType%>: answer} };
                 },
 
                 /**
@@ -54,7 +54,7 @@ define([
                  * @returns {Object}
                  */
                 getState() {
-                    return { response : { <%=jsonCardinality%> : answer } };
+                    return { response : { <%=jsonCardinality%> : { <%=baseType%>: answer} } };
                 },
 
                 /**


### PR DESCRIPTION
When generating a PCI runtime, the response format was wrong as it was missing the base type.